### PR TITLE
Restore terminal state on exit by properly closing TTY

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -43,7 +43,7 @@ func Intro(title string, opts ...MessageOptions) {
 		return
 	}
 
-	_, _ = fmt.Fprintf(out, "%s  %s\n%s\n", gray(BarStart), bold(title), gray(Bar))
+	_, _ = fmt.Fprintf(out, "%s  %s\n", gray(BarStart), bold(title))
 }
 
 // Outro prints a final outro (bar line, then bar end + message).

--- a/prompt.go
+++ b/prompt.go
@@ -669,6 +669,11 @@ func runWithTerminal[T any](fn func(Reader, Writer) T) T {
 		return zero
 	}
 
+	defer func() {
+		// Close the terminal to restore the TTY to its original state
+		_ = t.Close()
+	}()
+
 	return fn(t.Reader, t.Writer)
 }
 

--- a/prompt.go
+++ b/prompt.go
@@ -45,6 +45,7 @@ type Prompt struct {
 
 	cleanup func()
 	cur     *promptState
+	term    *terminal.Terminal // Reference to the terminal for listening to cancel signal
 }
 
 type promptState struct {
@@ -178,7 +179,9 @@ func NewPromptWithTracking(options PromptOptions, trackValue bool) *Prompt {
 		evOutCh:     evOut,
 		doneCh:      make(chan any, 1),
 		stopped:     make(chan struct{}),
+		term:        nil, // Will be set by runWithTerminal
 	}
+
 	// Default TTY will be provided by a higher-level adapter when needed
 	p.snap.Store(promptState{State: StateInitial})
 
@@ -188,6 +191,11 @@ func NewPromptWithTracking(options PromptOptions, trackValue bool) *Prompt {
 // On subscribes to an event
 func (p *Prompt) On(event string, handler any) {
 	p.preSubs[event] = append(p.preSubs[event], handler)
+}
+
+// SetTerminal sets the terminal reference for listening to cancel signals
+func (p *Prompt) SetTerminal(t *terminal.Terminal) {
+	p.term = t
 }
 
 // Emit emits an event to all subscribers
@@ -274,6 +282,20 @@ func (p *Prompt) Prompt(ctx context.Context) any {
 
 			select {
 			case p.evCh <- func(s *promptState) { p.handleAbort(s) }:
+			case <-p.stopped:
+			}
+		}()
+	}
+
+	// Listen for terminal cancel signal (Ctrl+C)
+	if p.term != nil {
+		go func() {
+			select {
+			case <-p.term.Cancel():
+				select {
+				case p.evCh <- func(s *promptState) { p.handleAbort(s) }:
+				case <-p.stopped:
+				}
 			case <-p.stopped:
 			}
 		}()
@@ -675,6 +697,28 @@ func runWithTerminal[T any](fn func(Reader, Writer) T) T {
 	}()
 
 	return fn(t.Reader, t.Writer)
+}
+
+// runWithTerminalAndRef creates a terminal and passes both I/O and the terminal reference
+// This is used internally to allow prompts to listen for Ctrl+C signals
+func runWithTerminalAndRef[T any](fn func(Reader, Writer, *terminal.Terminal) T) T {
+	if ioReader != nil || ioWriter != nil {
+		// When using mock I/O, we can't provide a real terminal
+		return fn(ioReader, ioWriter, nil)
+	}
+
+	t, err := terminal.New()
+	if err != nil {
+		var zero T
+		return zero
+	}
+
+	defer func() {
+		// Close the terminal to restore the TTY to its original state
+		_ = t.Close()
+	}()
+
+	return fn(t.Reader, t.Writer, t)
 }
 
 // resolveWriter returns the output writer and an optional terminal to close.


### PR DESCRIPTION
Description:
Once the program finishes running, the terminal doesn’t return to its normal behavior. Although keystrokes are still being captured internally, nothing is shown on screen. The cursor keeps blinking, but the characters the user types are invisible, making it feel like the terminal is “broken”.

Root Cause: 
The terminal is opened in raw mode by go-tty but is never properly closed, leaving the terminal with echo disabled.

Expected Behavior: 
Terminal state should be restored to normal after the program exits, allowing users to see their input.

Solution:
- Add a Close() method to the Terminal struct that properly closes the TTY connection.
- Make sure Close() is always executed by calling it with defer inside runWithTerminal(), ensuring the terminal is cleaned up even if the program exits early.

Description:
syscall.SIGWINCH is not available on Windows, causing build/runtime failures when compiling for the Windows platform.

Solution:
Add platform-specific handling or conditional compilation to avoid using syscall.SIGWINCH on Windows.